### PR TITLE
Lazy-Load Assets

### DIFF
--- a/Assets/TexturesRegistry.cs
+++ b/Assets/TexturesRegistry.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
-using ReLogic.Content;
-using Terraria.ModLoader;
+using RealisticSky.Common.DataStructures;
 
 namespace RealisticSky.Assets
 {
@@ -11,16 +10,16 @@ namespace RealisticSky.Assets
     {
         public const string ExtraTexturesPath = $"{nameof(RealisticSky)}/Assets/ExtraTextures";
 
-        public static readonly Asset<Texture2D> BloomCircle = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/BloomCircle");
+        public static readonly LazyAsset<Texture2D> BloomCircle = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/BloomCircle");
 
-        public static readonly Asset<Texture2D> BloomCircleBig = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/BloomCircleBig");
+        public static readonly LazyAsset<Texture2D> BloomCircleBig = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/BloomCircleBig");
 
-        public static readonly Asset<Texture2D> CloudDensityMap = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/CloudDensityMap");
+        public static readonly LazyAsset<Texture2D> CloudDensityMap = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/CloudDensityMap");
 
-        public static readonly Asset<Texture2D> EclipseMoon = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/EclipseMoon");
+        public static readonly LazyAsset<Texture2D> EclipseMoon = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/EclipseMoon");
 
-        public static readonly Asset<Texture2D> Galaxy = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/Galaxy");
+        public static readonly LazyAsset<Texture2D> Galaxy = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/Galaxy");
 
-        public static readonly Asset<Texture2D> LensFlare = ModContent.Request<Texture2D>($"{ExtraTexturesPath}/LensFlare");
+        public static readonly LazyAsset<Texture2D> LensFlare = LazyAsset<Texture2D>.RequestAsync($"{ExtraTexturesPath}/LensFlare");
     }
 }

--- a/Common/DataStructures/LazyAsset.cs
+++ b/Common/DataStructures/LazyAsset.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using ReLogic.Content;
+using Terraria.ModLoader;
+
+namespace RealisticSky.Common.DataStructures
+{
+    /// <summary>
+    ///     <see cref="Asset{T}"/> wrapper that facilitates lazy-loading.
+    /// </summary>
+    /// <typeparam name="T">The asset type.</typeparam>
+    public readonly struct LazyAsset<T> where T : class
+    {
+        private readonly Lazy<Asset<T>> asset;
+
+        public Asset<T> Asset => asset.Value;
+
+        public T Value => asset.Value.Value;
+
+        public LazyAsset(Func<Asset<T>> func)
+        {
+            asset = new Lazy<Asset<T>>(func);
+        }
+
+        public LazyAsset<T> ImmediatelyGet()
+        {
+            Asset.Wait();
+            return this;
+        }
+
+        public static LazyAsset<T> RequestAsync(string path)
+        {
+            return new LazyAsset<T>(() => ModContent.Request<T>(path));
+        }
+
+        public static LazyAsset<T> RequestImmediate(string path)
+        {
+            return new LazyAsset<T>(() => ModContent.Request<T>(path, AssetRequestMode.ImmediateLoad));
+        }
+    }
+}

--- a/Content/NightSky/GalaxyRenderer.cs
+++ b/Content/NightSky/GalaxyRenderer.cs
@@ -52,7 +52,7 @@ namespace RealisticSky.Content.NightSky
 
         public static void Render()
         {
-            if (TexturesRegistry.Galaxy.IsDisposed)
+            if (TexturesRegistry.Galaxy.Asset.IsDisposed)
                 return;
 
             // Update the galaxy's opacity.

--- a/Content/Sun/SunRenderer.cs
+++ b/Content/Sun/SunRenderer.cs
@@ -11,7 +11,7 @@ namespace RealisticSky.Content.Sun
     {
         public static void Render(float sunriseAndSetInterpolant)
         {
-            if (TexturesRegistry.BloomCircle.IsDisposed)
+            if (TexturesRegistry.BloomCircle.Asset.IsDisposed)
                 return;
 
             // Make things stronger when in space, and weaker during sunrises and sunsets.
@@ -67,7 +67,7 @@ namespace RealisticSky.Content.Sun
 
         public static void DrawEclipseOverlay()
         {
-            if (TexturesRegistry.BloomCircle.IsDisposed)
+            if (TexturesRegistry.BloomCircle.Asset.IsDisposed)
                 return;
 
             Texture2D moon = TexturesRegistry.EclipseMoon.Value;


### PR DESCRIPTION
Postpones asset loading until the first time they're actually required. Ultimately reduces load times.